### PR TITLE
Update `wlmon` to work with `WL_Advanced`

### DIFF
--- a/data-collector/wear_levelling/wlmon/main/include/wlmon.h
+++ b/data-collector/wear_levelling/wlmon/main/include/wlmon.h
@@ -35,18 +35,44 @@ public :
      * @param flash_drv Instance of Flash_Access needed for read function
      *
      * @return
-     *       - ESP_OK, if WL status was reconstructed successfuly
+     *       - ESP_OK, if WL status was reconstructed successfully
      *       - ESP_ERR_INVALID_CRC, if CRC of wl_state_t that is read does not match its stored CRC
      *       - ESP_ERR_NO_MEM, if memory allocation for temp_buff fails
      *       - ESP_ERR_FLASH_OP_FAIL, if recovering pos from flash fails
     */
-    //TODO virtual or not?
     virtual esp_err_t reconstruct(wl_config_t *cfg, Flash_Access *flash_drv);
 
-    // write a complete WL status as JSON to the given buffer
-    esp_err_t write_wl_status_json(char *s, size_t n);
+    /**
+     * @brief Writes a complete WL status in JSON format to the given buffer of given length
+     *
+     * @param s Buffer for writing the JSON WL status into
+     * @param n Length in bytes of the buffer
+     *
+     * @return
+     *       - ESP_OK, if full write was successful
+     *       - ESP_FAIl, if JSON could not be written in full
+    */
+    virtual esp_err_t write_wl_status_json(char *s, size_t n);
 
-    esp_err_t resize_json_buffer(char **buffer, uint32_t *new_size);
+    /**
+     * @brief Reallocates given buffer to additionally fit erase counts from WL_Advanced
+     *
+     * @param[out] buffer Buffer to realloc. On failure it remains valid and of size as before calling this method
+     * @param[out] new_size New size of buffer after successful realloc
+     *
+     * @return
+     *       - ESP_OK, if buffer could be reallocated to fit erase counts
+     *       - ESP_ERR_NO_MEM, if realloc failed
+    */
+    virtual esp_err_t resize_json_buffer(char **buffer, uint32_t *new_size);
+
+    /**
+     * @brief Get detected WL mode
+     *
+     * @return {WL_MODE_ADVANCED,WL_MODE_BASE,WL_MODE_UNDEFINED}
+    */
+    //TODO typedef enum for wl_mode_* type?
+    virtual uint8_t get_wl_mode();
 
 private:
     int write_wl_config_json(char *s, size_t n);
@@ -54,23 +80,22 @@ private:
     int write_wl_mode_json(char *s, size_t n);
     int write_wl_erase_counts_json(char *s, size_t n);
 
-    //bool OkBuffSet(int pos);
     esp_err_t recoverPos();
-
-    /**
-     * @brief Check that WL state CRC matches its stored CRC
-     *
-     * @param state wl_state_t of which to check CRC
-     *
-     * @return
-     *       - ESP_OK, if calculated CRC matches stored CRC
-     *       - ESP_ERR_INVALID_CRC, if calculated CRC differs from stored CRC
-    */
     esp_err_t checkStateCRC(wl_state_t *state);
 
     unsigned int wl_mode;
 };
 
+/**
+ * @brief All-in-one convenience function.
+ * Allocates required buffers, instantiates wlmon, reconstructs status and writes JSON to buffer
+ *
+ * @param[out] buffer Buffer for JSON status output. Will be allocated to fit the JSON.
+ *
+ * @return
+ *       - ESP_OK, if all steps in getting WL status succeed
+ *       - various ESP_ERR_* otherwise
+*/
 esp_err_t wlmon_get_status(char **buffer);
 
 #endif // #ifndef _WLMON_H_

--- a/data-collector/wear_levelling/wlmon/main/include/wlmon.h
+++ b/data-collector/wear_levelling/wlmon/main/include/wlmon.h
@@ -2,6 +2,7 @@
 #define _WLMON_H_
 
 #include "WL_Flash.h"
+#include "WL_Advanced.h"
 #include "esp_partition.h"
 
 #ifndef WL_CFG_CRC_CONST
@@ -10,13 +11,17 @@
 
 #define WLMON_BUF_SIZE 4096
 
+#define WL_MODE_UNDEFINED 0x0
+#define WL_MODE_BASE 0x1
+#define WL_MODE_ADVANCED 0x2
+
 #define WL_RESULT_CHECK(result) \
     if (result != ESP_OK) { \
         ESP_LOGE(TAG,"%s(%d): result = 0x%08x", __FUNCTION__, __LINE__, result); \
         return (result); \
     }
 
-class WLmon_Flash: WL_Flash
+class WLmon_Flash: WL_Advanced
 {
 public :
     WLmon_Flash();
@@ -42,6 +47,10 @@ public :
 private:
     int write_wl_config_json(char *s, size_t n);
     int write_wl_state_json(char *s, size_t n);
+    int write_wl_mode_json(char *s, size_t n);
+
+    //bool OkBuffSet(int pos);
+    esp_err_t recoverPos();
 
     /**
      * @brief Check that WL state CRC matches its stored CRC
@@ -53,6 +62,8 @@ private:
      *       - ESP_ERR_INVALID_CRC, if calculated CRC differs from stored CRC
     */
     esp_err_t checkStateCRC(wl_state_t *state);
+
+    unsigned int wl_mode;
 };
 
 esp_err_t wlmon_get_status(char **buffer);

--- a/data-collector/wear_levelling/wlmon/main/include/wlmon.h
+++ b/data-collector/wear_levelling/wlmon/main/include/wlmon.h
@@ -48,6 +48,7 @@ private:
     int write_wl_config_json(char *s, size_t n);
     int write_wl_state_json(char *s, size_t n);
     int write_wl_mode_json(char *s, size_t n);
+    int write_wl_erase_counts_json(char *s, size_t n);
 
     //bool OkBuffSet(int pos);
     esp_err_t recoverPos();

--- a/data-collector/wear_levelling/wlmon/main/include/wlmon.h
+++ b/data-collector/wear_levelling/wlmon/main/include/wlmon.h
@@ -9,6 +9,7 @@
 #define WL_CFG_CRC_CONST UINT32_MAX
 #endif
 
+#define WLMON_DEFAULT_BUF_SIZE 500
 #define WLMON_BUF_SIZE 4096
 
 #define WL_MODE_UNDEFINED 0x0
@@ -42,7 +43,10 @@ public :
     //TODO virtual or not?
     virtual esp_err_t reconstruct(wl_config_t *cfg, Flash_Access *flash_drv);
 
+    // write a complete WL status as JSON to the given buffer
     esp_err_t write_wl_status_json(char *s, size_t n);
+
+    esp_err_t resize_json_buffer(char **buffer, uint32_t *new_size);
 
 private:
     int write_wl_config_json(char *s, size_t n);

--- a/data-collector/wear_levelling/wlmon/main/wlmon.cpp
+++ b/data-collector/wear_levelling/wlmon/main/wlmon.cpp
@@ -83,7 +83,7 @@ esp_err_t get_wl_partition(const esp_partition_t **partition)
     // subtype any for potential data partitions different than FAT
     esp_partition_iterator_t iterator = esp_partition_find(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_ANY, NULL);
 
-    // iterate throught all data partitions
+    // iterate through all data partitions
     while (iterator != NULL)
     {
         candidate = esp_partition_get(iterator);


### PR DESCRIPTION
- [x] ~~check erase counts to detect~~ detecting advanced v base from recovered pos
- [x] also erase counts to JSON
- [x] snprintf buffer size: config+state has fixed maximum size (advanced), erase counts could be estimated/calculated