### PR TITLE
`wl-sim` further tweaks and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,12 @@ Project includes an extended version of [base wear leveling](https://docs.espres
 
 ## Installation and usage
 
-### 0. Clone repo
+### 0. Prerequisites and cloning
+
+- Set up `ESP-IDF` on your system. Currently the **only tested version is `v5.0`**.  For instructions see Espressif's [get started guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html)
+- Get yourself a `Python3` installation with `tkinter` for running the GUI part of this project. This will heavily depend on your system and current installations/configurations, so you're on your own for this one
+
+Once ready to proceed, clone this repo
 
 ```
 git clone https://github.com/omnitex/espwlmon.git && cd espwlmon
@@ -31,13 +36,15 @@ This will allow `WL_Advanced` to initialize all structures in flash from a clean
 
 ### 2a. Test with `erase_stress_example`
 
+*Warning: Running this will repeatedly perform erases in flash memory of you device, (really) slowly wearing it out.*
+
 ```
 cd erase_stress_example && idf.py flash monitor
 ```
 
 The provided example is a simple project for testing FAT read/write + memory erase stressing which builds up `WL_Advanced` records about sector erases in flash.
 
-Letting it run fully will take some time. Feel free to stop it after at least a run or two (see the logs while it runs) and move onto step 3.
+Letting it run fully will take some time. Feel free to stop it after at least a run or two (see the logs while it runs) and move onto step 3. But keep in mind the longer it runs the better - at least for visualization in step 4.
 
 ### 2b. Run your own project
 
@@ -64,11 +71,8 @@ This will flash the embedded part of the monitoring tool to your device. Making 
 
 Navigate back to the root of this repo, wherever you've cloned it and run the following.
 
-<!-- TODO pip vs pip3 -->
 ```
-pip3 install -r requirements.txt
-```
-```
+python3 -m pip install -r requirements.txt
 python3 espwlmon.py --port PORT
 ```
 

--- a/data-collector/wear_levelling/private_include/WL_Advanced.h
+++ b/data-collector/wear_levelling/private_include/WL_Advanced.h
@@ -30,6 +30,10 @@ protected:
     size_t addr_erase_counts1;
     size_t addr_erase_counts2;
 
+    uint8_t feistel_bit_width;
+    uint8_t feistel_msb_width;
+    uint8_t feistel_lsb_width;
+
     virtual esp_err_t updateEraseCounts();
     virtual esp_err_t writeEraseCounts(size_t erase_counts_addr);
     virtual esp_err_t readEraseCounts();

--- a/data-collector/wear_levelling/wlmon/main/include/wlmon.h
+++ b/data-collector/wear_levelling/wlmon/main/include/wlmon.h
@@ -9,7 +9,6 @@
 #endif
 
 #define WLMON_DEFAULT_BUF_SIZE 500
-#define WLMON_BUF_SIZE 4096
 
 typedef enum WL_MODE { WL_MODE_UNDEFINED = 0, WL_MODE_BASE, WL_MODE_ADVANCED } wl_mode_t;
 

--- a/data-collector/wear_levelling/wlmon/main/wlmon.cpp
+++ b/data-collector/wear_levelling/wlmon/main/wlmon.cpp
@@ -36,7 +36,7 @@ esp_err_t checkConfigCRC(wl_config_t *cfg)
  *
  * @return
  *       - ESP_OK, if config was read, is valid and written correctly;
- *       - ESP_ERR_NOT_SUPPORTED, if partition has encrypted flag set (TODO could we work with encrypted parititon?)
+ *       - ESP_ERR_NOT_SUPPORTED, if partition has encrypted flag set
  *       - ESP_ERR_INVALID_CRC, if config CRC failed to match its stored CRC
 */
 esp_err_t get_wl_config(wl_config_t *cfg, const esp_partition_t *partition)
@@ -61,14 +61,14 @@ esp_err_t get_wl_config(wl_config_t *cfg, const esp_partition_t *partition)
 }
 
 /**
- * @brief Find and return WL partition, if present (in flash or in partition image, target vs linux, TODO).
+ * @brief Find and return WL partition, if present in flash
  *
  * @param[out] partition Pointer for passing found (or constructed) WL partition
  *
  * @return
  *       - ESP_OK, if WL partition is found and config is retrieved, including CRC check
  *       - ESP_ERR_NOT_FOUND, if no candidate for WL partition was found
- *       - ESP_ERR_NOT_SUPPORTED, if last processed candidate paritition was encrypted
+ *       - ESP_ERR_NOT_SUPPORTED, if last processed candidate partition was encrypted
  *       - ESP_ERR_INVALID_CRC, if last processed candidate partition failed config CRC check
  *       - ESP_ERR_NOT_FOUND, if no candidate partition is found
 */

--- a/wl-sim/main/WLsim_Flash.cpp
+++ b/wl-sim/main/WLsim_Flash.cpp
@@ -39,8 +39,6 @@ static uint32_t feistel_calls = 0;
 static uint32_t feistel_cycle_walks;
 // was Feistel initialized and should be used in calcAddr?
 static bool feistel = false;
-// normalized endurance
-static double NE;
 
 void init_feistel(bool verbose)
 {
@@ -253,7 +251,7 @@ void print_output()
     // NE = ------------------------------------ x 100%
     //               Wmax x Num Sectors
     // and +1 for dummy sector here as well
-    NE = ((double)sum / (double)(SECTOR_ERASE_ENDURANCE * (SECTOR_COUNT + 1)) * 100);
+    double NE = ((double)sum / (double)(SECTOR_ERASE_ENDURANCE * (SECTOR_COUNT + 1)) * 100);
 
     printf("NE %f cycle_walks %u restarted %u\n", NE, feistel_cycle_walks, restarted);
 }

--- a/wl-sim/main/include/wl_sim.h
+++ b/wl-sim/main/include/wl_sim.h
@@ -10,6 +10,7 @@
 #define STATE_SIZE 0x2000
 #define CFG_SIZE 0x1000
 
+// -1 for reserving dummy sector
 #define FLASH_SIZE (((FULL_MEM_SIZE - STATE_SIZE * 2 - CFG_SIZE) / PAGE_SIZE - 1 ) * PAGE_SIZE)
 
 #define UPDATERATE 0x10

--- a/wl-sim/main/main.cpp
+++ b/wl-sim/main/main.cpp
@@ -21,7 +21,6 @@ int feistel_test();
 int main(int argc, char **argv)
 {
     srand(time(0));
-    esp_err_t result;
 
     // if single argument 'test', run the mapping correctness test
     if (argc == 2 && strcmp(argv[1], "test") == 0) {
@@ -39,7 +38,7 @@ int main(int argc, char **argv)
 \tBLOCKS_SIZE_FUNC: z for zipf, c for const\n\
 \tBLOCK_SIZE: N for max erase block size\n\
 \tRESTART_PROB: P for restart probability after every erase [per mille]\n");
-        return ESP_FAIL;
+        return -1;
     }
 
     // argument parsing
@@ -79,19 +78,19 @@ int main(int argc, char **argv)
     int erase_block_size = strtol(argv[4], &end, 10);
     if (*end != '\0') {
         fprintf(stderr, "Invalid erase block size '%s'!\n", argv[4]);
-        return ESP_FAIL;
+        return -1;
     } else if (erase_block_size <= 0) {
         fprintf(stderr, "Invalid erase block size %i, must be > 0\n", erase_block_size);
-        return ESP_FAIL;
+        return -1;
     }
 
     int restart_prob = strtol(argv[5], &end, 10);
     if (*end != '\0') {
         fprintf(stderr, "Invalid restart probability %s'!\n", argv[5]);
-        return ESP_FAIL;
+        return -1;
     } else if (restart_prob < 0) {
         fprintf(stderr, "Invalid restart probability %i, must be > 0 or 0 to turn off random restarting\n", restart_prob);
-        return ESP_FAIL;
+        return -1;
     }
 
     // if Feistel enabled from args, init keys and variables
@@ -100,15 +99,7 @@ int main(int argc, char **argv)
     }
 
     // runs until any sector reaches erase lifetime, see erase_sector()
-    for (;;) {
-        result = erase_range(addr_func(FLASH_SIZE), ERASE_SIZE * block_func(erase_block_size));
-
-        // non OK result returned only on sector reaching lifetime meaning we should end simulation run
-        if (result != ESP_OK) {
-            break;
-        }
-
-        // otherwise continue
+    while (erase_range(addr_func(FLASH_SIZE), ERASE_SIZE * block_func(erase_block_size)) == ESP_OK) {
 
         // if nonzero restart probability from arguments
         if (restart_prob != 0) {

--- a/wl-sim/plot.py
+++ b/wl-sim/plot.py
@@ -1,0 +1,57 @@
+#! /usr/bin/env python3
+
+import os
+import matplotlib.pyplot as plt
+import numpy as np
+
+OUTPUT_DIR = "graphs"
+
+if not os.path.exists(OUTPUT_DIR):
+    os.mkdir(OUTPUT_DIR)
+
+# based on https://matplotlib.org/stable/gallery/lines_bars_and_markers/barchart.html
+def plot(base, advanced, name):
+
+    block_sizes = ("1 sector", "5 sectors", "10 sectors", "20 sectors", "30 sectors", "40 sectors", "50 sectors")
+    values = {
+        "base": base,
+        "advanced": advanced
+    }
+
+    x = np.arange(len(block_sizes))  # the label locations
+    width = 0.35  # the width of the bars
+    multiplier = 0
+
+    fig, ax = plt.subplots(layout='constrained')
+
+    for attribute, measurement in values.items():
+        offset = width * multiplier
+        rects = ax.bar(x + offset, measurement, width, edgecolor="black" , label=attribute, hatch="//" if attribute == "advanced" else "")
+        #ax.bar_label(rects, padding=3)
+        multiplier += 1
+
+    # Add some text for labels, title and custom x-axis tick labels, etc.
+    ax.set_ylabel('Normalized Endurance (%)')
+    #ax.set_title('Penguin attributes by species')
+    ax.set_xticks(x + width, block_sizes)
+    ax.set_yticks(range(95, 101))
+    ax.legend(loc='upper left', ncols=2)
+    ax.set_ylim(95, 100)
+    ax.set_axisbelow(True)
+    ax.yaxis.grid(color='gray')
+    ax.set_aspect('equal')
+
+    #plt.show()
+    plt.savefig(f"{OUTPUT_DIR}/{name}.pdf")
+
+
+# results copied by hand
+# base vs advanced for constant address, constant block sizes and no restarting
+b_c_c_n_0 = (96.024, 96.0879, 96.1679, 96.3279, 96.4879, 96.6478, 96.8078)
+f_c_c_n_0 = (96.0244, 98.032, 98.7949, 99.5187, 99.6869, 99.7703, 99.7909)
+plot(b_c_c_n_0, f_c_c_n_0, "NE_c_c_n_0")
+
+# base vs advanced for zipf address, constant block sizes, no restarting
+b_z_c_n_0 = (97.2029, 97.5096, 97.7502, 98.0624, 98.1132, 98.3063, 98.5889)
+f_z_c_n_0 = (98.6283, 98.9036, 99.0796, 99.2648, 99.3052, 99.3258, 99.3745)
+plot(b_z_c_n_0, f_z_c_n_0, "NE_z_c_n_0")

--- a/wl-sim/run.sh
+++ b/wl-sim/run.sh
@@ -54,7 +54,7 @@ fi
 past_runs=$(eval cat $file | wc -l)
 
 # max simulation runs for given parameter combination (each combination => unique file name)
-N_MAX=30
+N_MAX=100
 
 # if past runs have not reached max number, calculate remaining runs
 if [[ "$past_runs" -lt "$N_MAX" ]]; then

--- a/wl-sim/run.sh
+++ b/wl-sim/run.sh
@@ -42,14 +42,33 @@ if [ "$1" = "test" ]; then
     exit 0
 fi
 
-# output log file with name based on current timestamp
-file="wl-sim.$1-$2-$3-$4-$5.$(date +%Y%m%d%H%M%S).log"
+# output log file with name based on simulation params
+file="wl-sim.$1-$2-$3-$4-$5.log"
 
-# register response Ctrl+C to remove log file and exit
-trap "rm -f $file; exit 0" SIGINT
+# if file does not exist i.e. from previous simulation runs, create it
+if [ ! -f $file ]; then
+    touch $file
+fi
 
-# number of simulation runs
-N=10
+# get number of past runs, where every line with simulation results == one run
+past_runs=$(eval cat $file | wc -l)
+
+# max simulation runs for given parameter combination (each combination => unique file name)
+N_MAX=30
+
+# if past runs have not reached max number, calculate remaining runs
+if [[ "$past_runs" -lt "$N_MAX" ]]; then
+    # number of simulation runs to add in this execution
+    N=$(($N_MAX - $past_runs))
+else
+    # otherwise set N to 0 so the following loop will not run
+    N=0
+fi
+
+if [[ "$N" > 0 ]]; then
+    echo "Detected $past_runs past results"
+    echo "Running..."
+fi
 
 # run wl-sim N times, appending output to file
 for ((i = 1; i <= $N; i++)); do
@@ -57,7 +76,7 @@ for ((i = 1; i <= $N; i++)); do
     $BINARY $1 $2 $3 $4 $5 2>&1 >> $file
     # nonzero return code signifies failure
     if [ "$?" != "0" ]; then
-        echo "Run $i/$N failed"
+        echo "Run $(($past_runs + $i))/$(($past_runs + $N)) failed"
         # run once again without redirecting stdout
         $BINARY $1 $2 $3 $4 $5
         echo "Example: $0 f z z 10 0"
@@ -66,11 +85,22 @@ for ((i = 1; i <= $N; i++)); do
         exit $?
     fi
     # otherwise report iteration number and wait a little bit for next round as address randomization is seeded by current timestamp
-    echo "($i/$N)"
+    # report x/N including past runs
+    echo "($(($past_runs + $i))/$(($past_runs + $N)))"
     sleep 0.01
 done
 
-# calculate average values of normalized endurance and cycle walks, append to file as well
-averages=$(eval cat $file | awk '{ NE_sum += $2; cycle_walk_sum += $4; restarted_sum += $6} END { print "avg(NE):", NE_sum/NR, "avg(cycle_walks):", cycle_walk_sum/NR, "avg(restarted):", restarted_sum/NR }')
-echo "$averages" >> $file
-echo "$averages"
+# if after the loop we got to the max number of results we wanted as set by N_MAX
+# calculate and report averages
+if [[ $(eval cat $file | wc -l) == $N_MAX ]]; then
+    averages=$(eval cat $file | awk '{ NE_sum += $2; cycle_walk_sum += $4; restarted_sum += $6} END { print "avg(NE):", NE_sum/NR, "avg(cycle_walks):", cycle_walk_sum/NR, "avg(restarted):", restarted_sum/NR }')
+    # also append to file
+    echo "$averages" >> $file
+    # and print
+    echo "Simulation finished!"
+    echo "$averages"
+else
+    # if not, that means averages got already appended, in that case, print them from the last line
+    echo "Results already calculated, reading from file:"
+    tail -n1 $file
+fi


### PR DESCRIPTION
Updated `run.sh` to allow for piece-wise measurements and set it to run 100 times per configuration. Ran it and manually copied the results to a Python script `plot.py` for plotting bar graphs as the visual output of `wl-sim`.

- [x] address comments in https://github.com/omnitex/espwlmon/pull/23